### PR TITLE
Add spi bus support

### DIFF
--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -37,7 +37,11 @@
     #elif defined(ETH_USE_FSPI)
       SPIClass spiETH = SPIClass(FSPI);
     #else // use FSPI port
-      SPIClass spiETH = SPI;
+        #ifdef ARDUINO_ARCH_SAMD
+          SPIClassSAMD spiETH = SPI;
+        #else
+          SPIClass spiETH = SPI;
+        #endif
     #endif
 #endif
 
@@ -48,10 +52,17 @@ DhcpClass* EthernetClass::_dhcp = NULL;
 ** Function name:           getSPIinstance
 ** Description:             Get the instance of the SPI class
 ***************************************************************************************/
-SPIClass& EthernetClass::getSPIinstance(void)
-{
-  return spiETH;
-} 
+#if defined(ARDUINO_ARCH_SAMD)
+  SPIClassSAMD& EthernetClass::getSPIinstance(void)
+  {
+    return spiETH;
+  }
+#else
+  SPIClass& EthernetClass::getSPIinstance(void)
+  {
+    return spiETH;
+  }
+#endif
 
 int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -37,7 +37,7 @@
     #elif defined(ETH_USE_FSPI)
       SPIClass spiETH = SPIClass(FSPI);
     #else // use FSPI port
-      SPIClass& spiETH = SPI;
+      SPIClass spiETH = SPI;
     #endif
 #endif
 

--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -23,8 +23,35 @@
 #include "utility/w5100.h"
 #include "Dhcp.h"
 
+#ifdef CONFIG_IDF_TARGET_ESP32
+    #ifdef ETH_USE_HSPI
+      SPIClass spiETH = SPIClass(HSPI);
+    #elif defined(ETH_USE_FSPI)
+      SPIClass spiETH = SPIClass(FSPI);
+    #else // use default VSPI port
+      SPIClass spiETH = SPIClass(VSPI);
+    #endif
+#else
+    #ifdef ETH_USE_HSPI
+      SPIClass spiETH = SPIClass(HSPI);
+    #elif defined(ETH_USE_FSPI)
+      SPIClass spiETH = SPIClass(FSPI);
+    #else // use FSPI port
+      SPIClass& spiETH = SPI;
+    #endif
+#endif
+
 IPAddress EthernetClass::_dnsServerAddress;
 DhcpClass* EthernetClass::_dhcp = NULL;
+
+/***************************************************************************************
+** Function name:           getSPIinstance
+** Description:             Get the instance of the SPI class
+***************************************************************************************/
+SPIClass& EthernetClass::getSPIinstance(void)
+{
+  return spiETH;
+} 
 
 int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
@@ -33,21 +60,21 @@ int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long resp
 
 	// Initialise the basic info
 	if (W5100.init() == 0) return 0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
 	W5100.setIPAddress(IPAddress(0,0,0,0).raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 
 	// Now try to get our config info from a DHCP server
 	int ret = _dhcp->beginWithDHCP(mac, timeout, responseTimeout);
 	if (ret == 1) {
 		// We've successfully found a DHCP server and got our configuration
 		// info, so set things accordingly
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 		W5100.setIPAddress(_dhcp->getLocalIp().raw_address());
 		W5100.setGatewayIp(_dhcp->getGatewayIp().raw_address());
 		W5100.setSubnetMask(_dhcp->getSubnetMask().raw_address());
-		SPI.endTransaction();
+		spiETH.endTransaction();
 		_dnsServerAddress = _dhcp->getDnsServerIp();
 		socketPortRand(micros());
 	}
@@ -81,7 +108,7 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet)
 {
 	if (W5100.init() == 0) return;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
 #ifdef ESP8266
 	W5100.setIPAddress(&ip[0]);
@@ -96,7 +123,7 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 	W5100.setGatewayIp(gateway._address);
 	W5100.setSubnetMask(subnet._address);
 #endif
-	SPI.endTransaction();
+	spiETH.endTransaction();
 	_dnsServerAddress = dns;
 }
 
@@ -138,11 +165,11 @@ int EthernetClass::maintain()
 		case DHCP_CHECK_RENEW_OK:
 		case DHCP_CHECK_REBIND_OK:
 			//we might have got a new IP.
-			SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+			spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 			W5100.setIPAddress(_dhcp->getLocalIp().raw_address());
 			W5100.setGatewayIp(_dhcp->getGatewayIp().raw_address());
 			W5100.setSubnetMask(_dhcp->getSubnetMask().raw_address());
-			SPI.endTransaction();
+			spiETH.endTransaction();
 			_dnsServerAddress = _dhcp->getDnsServerIp();
 			break;
 		default:
@@ -156,82 +183,82 @@ int EthernetClass::maintain()
 
 void EthernetClass::MACAddress(uint8_t *mac_address)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getMACAddress(mac_address);
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 IPAddress EthernetClass::localIP()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getIPAddress(ret.raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 	return ret;
 }
 
 IPAddress EthernetClass::subnetMask()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getSubnetMask(ret.raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 	return ret;
 }
 
 IPAddress EthernetClass::gatewayIP()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getGatewayIp(ret.raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 	return ret;
 }
 
 void EthernetClass::setMACAddress(const uint8_t *mac_address)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac_address);
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 void EthernetClass::setLocalIP(const IPAddress local_ip)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = local_ip;
 	W5100.setIPAddress(ip.raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 void EthernetClass::setSubnetMask(const IPAddress subnet)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = subnet;
 	W5100.setSubnetMask(ip.raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 void EthernetClass::setGatewayIP(const IPAddress gateway)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = gateway;
 	W5100.setGatewayIp(ip.raw_address());
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 void EthernetClass::setRetransmissionTimeout(uint16_t milliseconds)
 {
 	if (milliseconds > 6553) milliseconds = 6553;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setRetransmissionTime(milliseconds * 10);
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 void EthernetClass::setRetransmissionCount(uint8_t num)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setRetransmissionCount(num);
-	SPI.endTransaction();
+	spiETH.endTransaction();
 }
 
 

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -111,7 +111,11 @@ public:
 	friend class EthernetUDP;
 
 	// Get SPI class handle
-	static   SPIClass& getSPIinstance(void);
+#ifdef ARDUINO_ARCH_SAMD
+	static   SPIClassSAMD& getSPIinstance(void); // Get SPI class handle
+#else
+	static   SPIClass& getSPIinstance(void); // Get SPI class handle
+#endif
 
 private:
 	// Opens a socket(TCP or UDP or IP_RAW mode)

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -49,6 +49,7 @@
 
 
 #include <Arduino.h>
+#include <SPI.h>
 #include "Client.h"
 #include "Server.h"
 #include "Udp.h"

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -108,6 +108,10 @@ public:
 	friend class EthernetClient;
 	friend class EthernetServer;
 	friend class EthernetUDP;
+
+	// Get SPI class handle
+	static   SPIClass& getSPIinstance(void);
+
 private:
 	// Opens a socket(TCP or UDP or IP_RAW mode)
 	static uint8_t socketBegin(uint8_t protocol, uint16_t port);

--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -101,7 +101,7 @@ uint8_t W5100Class::init(void)
 	delay(560);
 	//Serial.println("w5100 init");
 
-	#if defined(ETH_SCLK) && defined(ETH_MISO) && defined(ETH_MOSI) && defined(ETHERNET_CS_PIN)       //***********
+	#if defined(ETH_SCLK) && defined(ETH_MISO) && defined(ETH_MOSI) && defined(ETHERNET_CS_PIN)
 	spiETH.begin(ETH_SCLK, ETH_MISO, ETH_MOSI, ETHERNET_CS_PIN);
 	#else
 	spiETH.begin();

--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -101,10 +101,14 @@ uint8_t W5100Class::init(void)
 	delay(560);
 	//Serial.println("w5100 init");
 
-	SPI.begin();
+	#if defined(ETH_SCLK) && defined(ETH_MISO) && defined(ETH_MOSI) && defined(ETHERNET_CS_PIN)       //***********
+	spiETH.begin(ETH_SCLK, ETH_MISO, ETH_MOSI, ETHERNET_CS_PIN);
+	#else
+	spiETH.begin();
+	#endif
 	initSS();
 	resetSS();
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 
 	// Attempt W5200 detection first, because W5200 does not properly
 	// reset its SPI state when CS goes high (inactive).  Communication
@@ -189,10 +193,10 @@ uint8_t W5100Class::init(void)
 	} else {
 		//Serial.println("no chip :-(");
 		chip = 0;
-		SPI.endTransaction();
+		spiETH.endTransaction();
 		return 0; // no known chip is responding :-(
 	}
-	SPI.endTransaction();
+	spiETH.endTransaction();
 	initialized = true;
 	return 1; // successful init
 }
@@ -276,15 +280,15 @@ W5100Linkstatus W5100Class::getLinkStatus()
 	if (!init()) return UNKNOWN;
 	switch (chip) {
 	  case 52:
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 		phystatus = readPSTATUS_W5200();
-		SPI.endTransaction();
+		spiETH.endTransaction();
 		if (phystatus & 0x20) return LINK_ON;
 		return LINK_OFF;
 	  case 55:
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		spiETH.beginTransaction(SPI_ETHERNET_SETTINGS);
 		phystatus = readPHYCFGR_W5500();
-		SPI.endTransaction();
+		spiETH.endTransaction();
 		if (phystatus & 0x01) return LINK_ON;
 		return LINK_OFF;
 	  default:
@@ -299,11 +303,11 @@ uint16_t W5100Class::write(uint16_t addr, const uint8_t *buf, uint16_t len)
 	if (chip == 51) {
 		for (uint16_t i=0; i<len; i++) {
 			setSS();
-			SPI.transfer(0xF0);
-			SPI.transfer(addr >> 8);
-			SPI.transfer(addr & 0xFF);
+			spiETH.transfer(0xF0);
+			spiETH.transfer(addr >> 8);
+			spiETH.transfer(addr & 0xFF);
 			addr++;
-			SPI.transfer(buf[i]);
+			spiETH.transfer(buf[i]);
 			resetSS();
 		}
 	} else if (chip == 52) {
@@ -312,13 +316,13 @@ uint16_t W5100Class::write(uint16_t addr, const uint8_t *buf, uint16_t len)
 		cmd[1] = addr & 0xFF;
 		cmd[2] = ((len >> 8) & 0x7F) | 0x80;
 		cmd[3] = len & 0xFF;
-		SPI.transfer(cmd, 4);
+		spiETH.transfer(cmd, 4);
 #ifdef SPI_HAS_TRANSFER_BUF
-		SPI.transfer(buf, NULL, len);
+		spiETH.transfer(buf, NULL, len);
 #else
 		// TODO: copy 8 bytes at a time to cmd[] and block transfer
 		for (uint16_t i=0; i < len; i++) {
-			SPI.transfer(buf[i]);
+			spiETH.transfer(buf[i]);
 		}
 #endif
 		resetSS();
@@ -366,15 +370,15 @@ uint16_t W5100Class::write(uint16_t addr, const uint8_t *buf, uint16_t len)
 			for (uint8_t i=0; i < len; i++) {
 				cmd[i + 3] = buf[i];
 			}
-			SPI.transfer(cmd, len + 3);
+			spiETH.transfer(cmd, len + 3);
 		} else {
-			SPI.transfer(cmd, 3);
+			spiETH.transfer(cmd, 3);
 #ifdef SPI_HAS_TRANSFER_BUF
-			SPI.transfer(buf, NULL, len);
+			spiETH.transfer(buf, NULL, len);
 #else
 			// TODO: copy 8 bytes at a time to cmd[] and block transfer
 			for (uint16_t i=0; i < len; i++) {
-				SPI.transfer(buf[i]);
+				spiETH.transfer(buf[i]);
 			}
 #endif
 		}
@@ -391,17 +395,17 @@ uint16_t W5100Class::read(uint16_t addr, uint8_t *buf, uint16_t len)
 		for (uint16_t i=0; i < len; i++) {
 			setSS();
 			#if 1
-			SPI.transfer(0x0F);
-			SPI.transfer(addr >> 8);
-			SPI.transfer(addr & 0xFF);
+			spiETH.transfer(0x0F);
+			spiETH.transfer(addr >> 8);
+			spiETH.transfer(addr & 0xFF);
 			addr++;
-			buf[i] = SPI.transfer(0);
+			buf[i] = spiETH.transfer(0);
 			#else
 			cmd[0] = 0x0F;
 			cmd[1] = addr >> 8;
 			cmd[2] = addr & 0xFF;
 			cmd[3] = 0;
-			SPI.transfer(cmd, 4); // TODO: why doesn't this work?
+			spiETH.transfer(cmd, 4); // TODO: why doesn't this work?
 			buf[i] = cmd[3];
 			addr++;
 			#endif
@@ -413,9 +417,9 @@ uint16_t W5100Class::read(uint16_t addr, uint8_t *buf, uint16_t len)
 		cmd[1] = addr & 0xFF;
 		cmd[2] = (len >> 8) & 0x7F;
 		cmd[3] = len & 0xFF;
-		SPI.transfer(cmd, 4);
+		spiETH.transfer(cmd, 4);
 		memset(buf, 0, len);
-		SPI.transfer(buf, len);
+		spiETH.transfer(buf, len);
 		resetSS();
 	} else { // chip == 55
 		setSS();
@@ -457,9 +461,9 @@ uint16_t W5100Class::read(uint16_t addr, uint8_t *buf, uint16_t len)
 			cmd[2] = ((addr >> 6) & 0xE0) | 0x18; // 2K buffers
 			#endif
 		}
-		SPI.transfer(cmd, 3);
+		spiETH.transfer(cmd, 3);
 		memset(buf, 0, len);
-		SPI.transfer(buf, len);
+		spiETH.transfer(buf, len);
 		resetSS();
 	}
 	return len;

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -17,7 +17,11 @@
 #include <Arduino.h>
 #include <SPI.h>
 
-extern SPIClass spiETH;
+#ifdef ARDUINO_ARCH_SAMD
+  extern SPIClassSAMD spiETH;
+#else
+  extern SPIClass spiETH;
+#endif
 
 // Safe for all chips
 #define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -17,6 +17,8 @@
 #include <Arduino.h>
 #include <SPI.h>
 
+extern SPIClass spiETH;
+
 // Safe for all chips
 #define SPI_ETHERNET_SETTINGS SPISettings(14000000, MSBFIRST, SPI_MODE0)
 


### PR DESCRIPTION
this will give the Ethernet library SPIClass support for use with different buses on ESP32, which is needed to make ethernet work on teh wt32-sc01 where the display is on another bus. teh way its setup should be non-breaking and require no intervention on devices currently using this Ethernet library.

I have been testing this locally and so far seems to work properly.